### PR TITLE
feat: SNI hostname allow list (:sni_allowed_hosts)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The following configuration values are optional and can be set in your `config.e
 - `addr`: The address to bind to for the ACME handshake. Defaults to `0.0.0.0` on IPv4 and `::` on IPv6.
 - `storage_module`: The module to use for storage. Defaults to `CertMagex.Storage.Acmev2Adapter`. Changing the module allows storing retrieved certificates in a different storage location.
 - `renewal_threshold`: The threshold for certificate renewal. Defaults to renewing certificates if they have `86_400` seconds (1 day) of validity left.
+- `sni_allowed_hosts`: If set to a **non-empty** list of hostnames, only those names (compared case-insensitively) will trigger certificate handling; any other TLS SNI value yields no certificate and does not run ACME. Useful to avoid spurious Let’s Encrypt requests from internet scanners. If unset or `[]`, every SNI is considered (the previous default).
 
 ### IP address certificates
 

--- a/lib/certmagex.ex
+++ b/lib/certmagex.ex
@@ -21,8 +21,17 @@ defmodule CertMagex do
     https: [port: 443, thousand_island_options: [transport_options: [sni_fun: &CertMagex.sni_fun/1]]],
     ...
   ```
+
+  ## SNI hostname allow list (optional)
+
+  With `sni_fun`, each TLS client SNI can trigger a certificate request. To avoid
+  issuing or renewing certificates for random scan traffic, set
+  `config :certmagex, :sni_allowed_hosts, ["www.example.com", "api.example.com"]`.
+  When this list is non-empty, only those hostnames (compared
+  case-insensitively) are handled; any other SNI returns `:undefined` and no
+  ACME work runs. If unset or `[]`, all SNIs are considered (unchanged default).
   """
-  alias CertMagex.{Worker, Storage}
+  alias CertMagex.{Storage, Worker}
   require Logger
 
   def sni_fun(domain) when is_list(domain) do
@@ -42,6 +51,30 @@ defmodule CertMagex do
   """
   def sni_fun(domain) when is_binary(domain) do
     Logger.debug("CertMagex: sni_fun called with domain: #{domain}")
+
+    if sni_host_allowlisted?(domain) do
+      sni_fun_allowed(domain)
+    else
+      :undefined
+    end
+  end
+
+  defp sni_host_allowlisted?(domain) do
+    case Application.get_env(:certmagex, :sni_allowed_hosts) do
+      hosts when is_list(hosts) and hosts != [] ->
+        host_in_sni_list?(domain, hosts)
+
+      _ ->
+        true
+    end
+  end
+
+  defp host_in_sni_list?(domain, hosts) do
+    d = String.downcase(domain)
+    Enum.any?(hosts, &(String.downcase(&1) == d))
+  end
+
+  defp sni_fun_allowed(domain) do
     provider = Application.get_env(:certmagex, :provider, :letsencrypt)
 
     if ip?(domain) and provider not in [:letsencrypt, :letsencrypt_test] do

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule CertMagex.MixProject do
   use Mix.Project
 
-  @version "1.2.0"
+  @version "1.3.0"
   @name "CertMagex"
   @url "https://github.com/dominicletz/certmagex"
   @maintainers ["Dominic Letz"]

--- a/test/certmagex_test.exs
+++ b/test/certmagex_test.exs
@@ -1,6 +1,21 @@
 defmodule CertMagexTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
   doctest CertMagex
+
+  describe "sni_fun/1 and :sni_allowed_hosts" do
+    test "returns :undefined when the hostname is not in the allow list" do
+      previous = Application.get_env(:certmagex, :sni_allowed_hosts)
+      Application.put_env(:certmagex, :sni_allowed_hosts, ["good.example.com"])
+
+      on_exit(fn ->
+        if previous,
+          do: Application.put_env(:certmagex, :sni_allowed_hosts, previous),
+          else: Application.delete_env(:certmagex, :sni_allowed_hosts)
+      end)
+
+      assert :undefined = CertMagex.sni_fun("scanner.example.com")
+    end
+  end
 
   describe "ip?/1" do
     test "returns true for IPv4 addresses" do


### PR DESCRIPTION
## Summary

Adds an optional `:sni_allowed_hosts` application config for CertMagex. When set to a **non-empty** list, only those hostnames (case-insensitive) go through the existing IP check and certificate cache/ACME path; any other TLS SNI returns `:undefined` without ACME. When unset or `[]`, behavior matches the previous default (all SNIs are considered).

## Motivation

This mirrors the allowlist pattern used in [Diode Console](https://github.com/diode) via `Console.CertSni` / `PHX_ADDITIONAL_SNI_HOSTS`, so apps can use plain `&CertMagex.sni_fun/1` without a wrapper module.

## Version

Bumps package to **v1.3.0**.

## Testing

- `mix test`
- New test: host not in allow list → `:undefined`